### PR TITLE
Check if cpars element is S4 Data before subsetting

### DIFF
--- a/R/SRA_scope.R
+++ b/R/SRA_scope.R
@@ -801,6 +801,8 @@ Sub_cpars <- function(OM, sims = 1:OM@nsim) {
         if(length(dim(x)) == 3) return(x[sims, , , drop = FALSE])
         if(length(dim(x)) == 4) return(x[sims, , , , drop = FALSE])
         if(length(dim(x)) == 5) return(x[sims, , , , , drop = FALSE])
+      } else if(class(x)[[1]] == "Data") {
+        x
       } else return(x[sims])
     }
 


### PR DESCRIPTION
Unless I'm missing something, this is required if setting `sims` to something other than the complete vector in the SRA plot function. I get an error that an S4 object is not subsettable. Not sure if you have a preferred way of checking for your Data element.